### PR TITLE
Fix Flystick input not working in 4.27 on rolv

### DIFF
--- a/Source/DTrackInput/Private/DTrackFlystickInputDevice.cpp
+++ b/Source/DTrackInput/Private/DTrackFlystickInputDevice.cpp
@@ -198,7 +198,7 @@ void FDTrackFlystickInputDevice::on_livelink_subject_added_handler(FLiveLinkSubj
 		return;
 	}
 
-	TSubclassOf<ULiveLinkRole> subject_role = m_livelink_client->GetSubjectRole(n_subject_key.SubjectName);
+	TSubclassOf<ULiveLinkRole> subject_role = m_livelink_client->GetSubjectRole(n_subject_key);
 	if (subject_role->IsChildOf(UDTrackFlystickInputRole::StaticClass()))
 	{
 		m_flysticks.Add(n_subject_key);


### PR DESCRIPTION
For some reason, using the key instead of the string works.